### PR TITLE
Feat/likes

### DIFF
--- a/app/likes/page.tsx
+++ b/app/likes/page.tsx
@@ -22,7 +22,11 @@ function toNum(v: unknown, fallback = 0) {
 function normalize(like: Like) {
   const m = like.mover;
   const driverName = (m.nickname ?? m.name ?? "이사 기사님").trim();
-  const description = (m.introduction ?? m.description ?? "").trim();
+  const introduction = (m.introduction ?? "").trim();
+  const description =
+    m.description.length < 25
+      ? m.description
+      : m.description.substring(0, 25) + "...";
   const avatarUrl = (m.img ?? "/assets/profile_mover_detail.svg").trim();
 
   const rating = toNum(m.averageRating, 0);
@@ -33,6 +37,7 @@ function normalize(like: Like) {
 
   return {
     driverName,
+    introduction,
     description,
     avatarUrl,
     rating,

--- a/app/search/MoverSearch.client.tsx
+++ b/app/search/MoverSearch.client.tsx
@@ -117,6 +117,8 @@ export default function MoverSearchClient({ initialParams }: Props) {
 
   if (!data) return null;
 
+  console.log(data.items);
+
   return (
     <div>
       <Grid

--- a/app/search/components/FavoritesAside.container.tsx
+++ b/app/search/components/FavoritesAside.container.tsx
@@ -40,8 +40,8 @@ function toFav(m: Mover): Fav {
           ? m.rating
           : 0,
     // 이동/확정 건수(백엔드 스키마에 맞춰 유연 처리)
-    moves: (m as any).moves ?? 0,
-    confirmed: (m as any)?._count?.quotes ?? (m as any).confirmedCount ?? 0,
+    moves: (m as any)._count?.reviews ?? 0,
+    confirmed: (m as any)?._count?.quotes ?? 0,
   };
 }
 

--- a/app/search/components/Grid.tsx
+++ b/app/search/components/Grid.tsx
@@ -18,24 +18,22 @@ function toNum(v: unknown, fallback = 0) {
 /** API 응답 Mover -> CardHeaderMover 에 필요한 형태로 바로 매핑 */
 function normalize(m: any) {
   const driverName = (m.nickname ?? m.name ?? "이사 기사님").trim();
-  const description = (m.introduction ?? m.description ?? "").trim();
+  const introduction = (m.introduction ?? "").trim();
+  const description =
+    m.description.length < 25
+      ? m.description
+      : m.description.substring(0, 25) + "...";
   const avatarUrl = (m.img ?? "/assets/profile_mover_detail.svg").trim();
 
   const rating = toNum(m.averageRating, 0);
-  const reviewCount = toNum(
-    m.totalReviews ?? (Array.isArray(m.reviews) ? m.reviews.length : undefined),
-    0,
-  );
+  const reviewCount = toNum(m._count.reviews, 0);
   const careerYears = toNum(m.career, 0);
-  const confirmedCount = Array.isArray(m.quotes) ? m.quotes.length : 0;
-
-  const likeCount = toNum(
-    m?._count?.likes ?? (Array.isArray(m.likes) ? m.likes.length : undefined),
-    0,
-  );
+  const confirmedCount = toNum(m._count.quotes, 0);
+  const likeCount = toNum(m._count.likes, 0);
 
   return {
     driverName,
+    introduction,
     description,
     avatarUrl,
     rating,
@@ -72,6 +70,7 @@ export default function Grid({
           {items.map((m) => {
             const n = normalize(m);
             const id = (m as any).id;
+            console.log(n);
 
             return (
               <Link key={id} href={`/movers/${id}`} className="block">

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import SearchControls from "./components/SearchControls";
 import MoverSearchClient from "./MoverSearch.client";
-import FavoritesAside from "./components/FavoritesAside";
 import FavoritesAsideContainer from "./components/FavoritesAside.container";
 
 export const metadata: Metadata = {
@@ -31,19 +30,6 @@ export default async function Page({
   const page = Number(pick(sp, "page") ?? 1) || 1;
 
   const initial = { q, region, service, sort, page };
-
-  // (선택) 오른쪽 사이드의 "찜한 기사님" 데이터
-  // 백엔드 준비되면 여기서 서버 fetch로 교체하면 됩니다.
-  const likedMovers: Array<{
-    id: string;
-    name: string;
-    title: string;
-    avatarUrl: string;
-    badge?: string; // 예: "사무실이사"
-    rating?: number; // 예: 5.0
-    moves?: number; // 예: 334건
-    confirmed?: number; // 예: 확정 N건
-  }> = [];
 
   return (
     <main className="mx-auto max-w-[1120px] px-6 py-6">

--- a/components/MoverHero.tsx
+++ b/components/MoverHero.tsx
@@ -7,12 +7,8 @@ import { Chip } from "@/components/common/chip/Chips";
 import Image from "next/image";
 import BaseModal from "./common/modal/DirectModal";
 import RequestList from "@/app/(mover)/movers/[moverId]/components/RequestList";
-import {
-  LikeActiveIcon,
-  ShareClipIcon,
-  ShareKakaoIcon,
-  ShareFacebookIcon,
-} from "@/components/common/button/icons";
+import { LikeActiveIcon } from "@/components/common/button/icons";
+import { toggleLike } from "@/lib/api/likes";
 
 type Props = { mover: any };
 
@@ -74,6 +70,12 @@ export default function MoverHero({ mover }: Props) {
   //   (지금은 API가 없어서 false → 섹션 렌더링 안 됨)
   const hasRealReviews =
     Array.isArray((mover as any)?.reviews) && (mover as any).reviews.length > 0;
+
+  const handleToggleLike = async (moverId: number) => {
+    const response = await toggleLike(moverId);
+    alert(response.message);
+    window.location.reload();
+  };
 
   return (
     <section className="relative">
@@ -216,6 +218,7 @@ export default function MoverHero({ mover }: Props) {
                   height={20}
                 />
               }
+              onClick={() => handleToggleLike(mover.id)}
             >
               기사님 찜하기
             </Buttons>

--- a/components/common/card/CardMover.tsx
+++ b/components/common/card/CardMover.tsx
@@ -9,6 +9,7 @@ import CardPrice from "./CardPrice";
 
 interface CardHeaderMoverProps {
   driverName: string;
+  introduction: string;
   description: string;
   avatarUrl?: string;
   className?: string;
@@ -22,6 +23,7 @@ interface CardHeaderMoverProps {
 
 export default function CardHeaderMover({
   driverName,
+  introduction,
   description,
   avatarUrl,
   className,
@@ -32,13 +34,14 @@ export default function CardHeaderMover({
   showPrice = true, // 기본값은 true
   likeCount = 0, // 기본값은 0
 }: CardHeaderMoverProps) {
+  console.log(`introduction: ${introduction} description: ${description}`);
   return (
-    <Card className={`w-130 space-y-3 ${className || ""}`}>
+    <Card className={`w-full space-y-3 ${className || ""}`}>
       <div className="flex items-center gap-3 pb-2">
         <MoverAvatar size={80} />
         <div className="flex flex-col gap-y-2">
           <div>
-            <MoverMessage message="고객님의 물품을 안전하게 운송해 드립니다." />
+            <MoverMessage message={introduction} />
             <MoverDescription description={description} />
           </div>
 

--- a/lib/api/likes.ts
+++ b/lib/api/likes.ts
@@ -28,6 +28,7 @@ export interface Like {
 // 고객의 좋아요 목록 조회
 export async function getCustomerLikes(): Promise<Like[]> {
   const response = await clientApi.get("/likes/customer");
+  console.log(response.data.data);
   return response.data.data;
 }
 


### PR DESCRIPTION
1. 기사 상세 페이지에서 찜하기 가능 (찜하기 하면 페이지 새로고침 진행됨. alert로 취소한 건지 새로 찜한건지 나타남. 추후 수정 필요)
2. 일반 회원으로 접속 후 /likes로 이동 시 여태 찜한 기사 목록 볼 수 있음
     - 선택하고 삭제하는(찜한 거에서 제외) 기능이 필요한데, 이거를 하려면 moverCard 컴포넌트를 같이 손봐야 해서 우선 안 했습니다.
3. moverCard 컴포넌트가 w-130으로 고정되어 있었는데, 이를 w-full로 수정함. 부모 요소 크기 100%로 상속받음.